### PR TITLE
docs: :memo: update Prysm domain to prysm.offchainlabs.com

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -558,7 +558,7 @@ Aug 09 12:34:05 remy-MINIPC-PN50 systemd[1]: Reloaded Prometheus.
 Aug 09 12:34:05 remy-MINIPC-PN50 prometheus[1934]: level=info ts=2021-08-09T16:34:05.304Z caller=main.go:981 msg="Loading configuration file" filename=/etc/prometheus/prometheus.yml
 Aug 09 12:34:05 remy-MINIPC-PN50 prometheus[1934]: level=info ts=2021-08-09T16:34:05.311Z caller=main.go:1012 msg="Completed loading of configuration file" filename=/etc/prometheus/prometheus.yml totalDuration=7.822144ms remote_storage=4.305µs web_handler=6.249µs query_engine=1.734µs scrape=1.831998ms scrape_sd=83.865µs notify=618.619µs notify_sd=51.754µs rules=1.993µs
 ```
-3. Import [the Prysm dashboard for Prometheus](https://docs.prylabs.network/assets/grafana-dashboards/small_amount_validators.json) in Grafana.
+3. Import [the Prysm dashboard for Prometheus](https://prysm.offchainlabs.com/docs/monitoring-alerts-metrics/grafana-dashboard/#creating-and-importing-dashboards) in Grafana.
 
 ### Lighthouse
 

--- a/docs/prepare-for-the-merge.md
+++ b/docs/prepare-for-the-merge.md
@@ -169,7 +169,7 @@ There are some privacy implications in using a fee recipient address. That addre
 
 Here are the detailed configuration options for the fee recipient for each client and their documentation.
 
-- [Prysm](https://docs.prylabs.network/docs/execution-node/fee-recipient)
+- [Prysm](https://prysm.offchainlabs.com/docs/configure-prysm/fee-recipient/)
 - [Nimbus](https://nimbus.guide/suggested-fee-recipient.html)
 - [Lodestar](https://chainsafe.github.io/lodestar/usage/validator-management/#configuring-the-fee-recipient-address)
 - [Teku](https://docs.teku.consensys.net/en/latest/HowTo/Prepare-for-The-Merge/#configure-the-fee-recipient)

--- a/docs/voluntary-exit.md
+++ b/docs/voluntary-exit.md
@@ -6,7 +6,7 @@ This guide is meant for people who are staking on Ethereum either through their 
 
 There are a lot of different ways to perform a voluntary exit. Each consensus client has their own documentation on this. This guide will focus on using [ethdo](https://github.com/wealdtech/ethdo) and [the beaconcha.in website](https://beaconcha.in/) to perform this task for simplicity. Check out the documentation for each client to learn more about how to do this natively.
 
-- [Prysm](https://docs.prylabs.network/docs/wallet/exiting-a-validator)
+- [Prysm](https://prysm.offchainlabs.com/docs/manage-validator/exiting-a-validator/)
 - [Nimbus](https://nimbus.guide/voluntary-exit.html)
 - [Lodestar](https://chainsafe.github.io/lodestar/run/validator-management/validator-cli#validator-voluntary-exit)
 - [Teku](https://docs.teku.consensys.net/HowTo/Voluntary-Exit)


### PR DESCRIPTION
Updated all documentation URLs from https://docs.prylabs.network/docs to https://prysm.offchainlabs.com/docs and new urls paths.